### PR TITLE
Document JSON demo workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,31 @@ Both implementations satisfy the supplied functional test. Declared
 reset-release intent separates them structurally. Preserve the complete
 reproducer with `svgap demo --output demo-output`.
 
+For a copy-pasteable machine-readable check, keep the generated artifacts out
+of Git and inspect the JSON summary:
+
+```bash
+svgap demo --json --output demo-output \
+  | jq '{status, safe: .safe.structural, unsafe: .unsafe.structural, findings: .unsafe.findings}'
+```
+
+```json
+{
+  "findings": [
+    "REF-RDC-001"
+  ],
+  "safe": "pass",
+  "status": "pass",
+  "unsafe": "fail"
+}
+```
+
+Attach `demo-output/summary.json`, both `*/build/report.json` files, and the
+preserved manifests/RTL sources to an issue or CI artifact when sharing a
+reproduction. The demo is a controlled witness that the supplied functional
+oracle does not identify the structural reset-release finding; it is not a
+defect-rate estimate or silicon signoff.
+
 The same workflow is available in the open-tool container:
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,35 @@ chip-design team” explicit for AI-generated digital RTL.
 - [Integrate an existing benchmark](integrating-existing-benchmarks.md)
 - [Study frontier-model handoff capability](frontier-model-research.md)
 
+## Copy-paste JSON demo
+
+Use `--json` with `--output` when a CI job, issue, or agent benchmark needs a
+machine-readable first result and a preserved reproducer:
+
+```bash
+svgap demo --json --output demo-output \
+  | jq '{status, safe: .safe.structural, unsafe: .unsafe.structural, findings: .unsafe.findings}'
+```
+
+```json
+{
+  "findings": [
+    "REF-RDC-001"
+  ],
+  "safe": "pass",
+  "status": "pass",
+  "unsafe": "fail"
+}
+```
+
+Attach `demo-output/summary.json`, both `*/build/report.json` files, and the
+preserved manifests/RTL sources when filing an issue or publishing a CI
+artifact. Do not commit `demo-output`; it is generated evidence.
+
+Claim boundary: this controlled witness shows that the supplied functional
+oracle does not identify the structural reset-release finding. It is not a
+defect-rate estimate or silicon signoff.
+
 ## Build the ecosystem
 
 - [Write a checker backend](backend-sdk.md)


### PR DESCRIPTION
## Summary

- Add a copy-paste JSON demo example for `svgap demo --json --output demo-output`
- Show a minimal `jq` projection for status, structural outcomes, and findings
- Document which generated artifacts are useful for issues or CI and restate the demo claim boundary

## Verification

- `PYTHONPATH=src python3 -c 'import sys; from svgap.cli import main; sys.exit(main())' demo --json --output demo-output | jq '{status, safe: .safe.structural, unsafe: .unsafe.structural, findings: .unsafe.findings}'`\n- `uvx --from 'mkdocs-material>=9.6,<10' mkdocs build --strict --site-dir /tmp/svgap-11-site-preverify`\n- `git diff --check -- README.md docs/index.md`\n\nGenerated `demo-output`, `.venv`, and temporary site artifacts were removed before commit.